### PR TITLE
ultraHighEnergyPhysics should now depend on appliedHighEnergyPhysics …

### DIFF
--- a/GameData/CommunityTechTree/Tree/CommunityTechTree.cfg
+++ b/GameData/CommunityTechTree/Tree/CommunityTechTree.cfg
@@ -459,7 +459,7 @@
 		}
 		Parent
 		{
-			parentID = highEnergyScience
+			parentID = appliedHighEnergyPhysics
 			lineFrom = RIGHT
 			lineTo = LEFT
 		}


### PR DESCRIPTION
…in highEnergyScience

now that ultraHighEnergyPhysics  is added, ultraHighEnergyPhysics  should require appliedHighEnergyPhysics  instead of highEnergyScience  This prevent crossing lines